### PR TITLE
New widget: ColumnChart

### DIFF
--- a/src/front/package.json
+++ b/src/front/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@consta/charts": "^0.6.4",
     "@consta/uikit": "^3.26.2",
     "@reduxjs/toolkit": "^1.8.5",
     "@testing-library/jest-dom": "^5.14.1",
@@ -18,11 +19,11 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-grid-layout": "^1.3.4",
+    "react-router": "^6.3.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.4.2",
-    "web-vitals": "^2.1.0",
-    "react-router": "^6.3.0",
-    "react-router-dom": "^6.3.0"
+    "web-vitals": "^2.1.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -51,5 +52,9 @@
   "devDependencies": {
     "@types/react-grid-layout": "^1.3.2",
     "@types/react-router-dom": "^5.3.3"
-  }
+  },
+  "description": "This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC"
 }

--- a/src/front/src/core/pages/GridLayout/GridLayout.tsx
+++ b/src/front/src/core/pages/GridLayout/GridLayout.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Responsive, WidthProvider} from "react-grid-layout";
 import {Block} from "./Block";
+import {ColumnChart} from "./Widgets/Charts/ColumnChart";
 import "react-grid-layout/css/styles.css"
 import "react-resizable/css/styles.css"
 import css from './Layout.module.css'
@@ -14,7 +15,8 @@ export const Layout: React.FC<IGridLayoutProps> = ({}) => {
     { i: "a", x: 0, y: 0, w: 1, h: 2},
     { i: "b", x: 1, y: 0, w: 3, h: 2, minW: 2, maxW: 4 },
     { i: "c", x: 4, y: 0, w: 1, h: 2},
-    { i: "d", x: 4, y: 0, w: 1, h: 2}
+    { i: "d", x: 4, y: 0, w: 1, h: 2},
+    { i: "e", x: 0, y: 1, w: 1, h: 2}
   ];
   return (
     <div className={css.mainContainer}>
@@ -28,6 +30,9 @@ export const Layout: React.FC<IGridLayoutProps> = ({}) => {
         <div key="c">c</div>
         <div key={'d'} className={css.widgetContainer}>
           <Block />
+        </div>
+        <div key={'e'} className={css.widgetContainer}>
+          <ColumnChart />
         </div>
       </ResponsiveReactGridLayout>
     </div>

--- a/src/front/src/core/pages/GridLayout/Layout.module.css
+++ b/src/front/src/core/pages/GridLayout/Layout.module.css
@@ -6,6 +6,12 @@
     flex: 1;
     flex-direction: column
 }
+.chartWidget {
+    overflow: hidden;
+    border: 1px solid black;
+    display: flex;
+    flex: 1;
+}
 .widgetContainer {
     display: flex;
     flex-grow: 1;

--- a/src/front/src/core/pages/GridLayout/Widgets/Charts/ColumnChart.tsx
+++ b/src/front/src/core/pages/GridLayout/Widgets/Charts/ColumnChart.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import css from '../../Layout.module.css'
+import {Column} from '@consta/charts/Column'
+import {MOCK_DATA_FOR_COLUMN_CHART} from '../__mock__'
+interface IColumnChartProps {
+
+}
+
+
+export const ColumnChart: React.FC<IColumnChartProps> = props => {
+    return <div className={css.chartWidget}>
+        <Column
+            style={{ overflow: 'hidden', width: '100em'}}
+            data={MOCK_DATA_FOR_COLUMN_CHART}
+            xField="parameter"
+            yField="number"
+        />
+    </div>;
+};

--- a/src/front/src/core/pages/GridLayout/Widgets/__mock__.tsx
+++ b/src/front/src/core/pages/GridLayout/Widgets/__mock__.tsx
@@ -1,0 +1,7 @@
+export const MOCK_DATA_FOR_COLUMN_CHART = [
+    { parameter: 'Параметр 1', number: 1234 },
+    { parameter: 'Параметр 2', number: 1083 },
+    { parameter: 'Параметр 3', number: 672 },
+    { parameter: 'Параметр 4', number: 301 },
+    { parameter: 'Параметр 5', number: 167 },
+]


### PR DESCRIPTION
Добавил столбчатую диаграмму на главную страницу в качестве виджета.

Вместо [consta-widgets](https://widgets.consta.design/?path=/story/common-start--page) использовал [consta-charts](https://charts.consta.design/?path=/docs/common-start--page). Отказался от библиотеки виджетов, т.к. не смог подружить с уже используемым consta-uikit. По имеющимся графикам, все вроде в целом похоже.

Сам график пока на мок данных строится, + можно еще поднастроить внешку по необходимости.